### PR TITLE
Fix migration issue in createRouter

### DIFF
--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -26,9 +26,7 @@ import MaintenancePage from './component/MaintenancePage.vue';
  */
 
 const router = createRouter({
-  base: process.env.ARIADNE_PUBLIC_PATH,
-  history: createWebHistory(),
-  mode: 'history',
+  history: createWebHistory(process.env.ARIADNE_PUBLIC_PATH),
   routes: [
     /*  Maintenance mode */
     // {


### PR DESCRIPTION
The base URL was not being set correctly as it should now be passed into the createWebHistory function as a parameter, as opposed to being an option on createRouter. The mode option is also removed in v3.